### PR TITLE
Fix license

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@ Icon
 Session.vim
 .netrwhist
 *~
+
+### Kate ###
+*.kate-swp

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -1,0 +1,11 @@
+Contributors to the Pelican Elegant project (in alphabetical order of first name):
+
+- [André Burgaud – andreburgaud](https://github.com/andreburgaud)
+- [Brian Levin – bnice5000](https://github.com/bnice5000)
+– [Matija Šuklje – silverhook](https://github.com/silverhook)
+- [Miguel Lechón – debiatan](https://github.com/debiatan)
+- [Rod Morehead – rmorehead](https://github.com/rmorehead)
+- [Talha Mansoor – talha131](https://github.com/talha131)
+- [Tshepang Lekhonkhobe – tshepang](https://github.com/tshepang)
+- [calfzhou](https://github.com/calfzhou)
+- [Xin Yue – yuex](https://github.com/yuex)

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -2,7 +2,7 @@ Contributors to the Pelican Elegant project (in alphabetical order of first name
 
 - [André Burgaud – andreburgaud](https://github.com/andreburgaud)
 - [Brian Levin – bnice5000](https://github.com/bnice5000)
-– [Matija Šuklje – silverhook](https://github.com/silverhook)
+- [Matija Šuklje – silverhook](https://github.com/silverhook)
 - [Miguel Lechón – debiatan](https://github.com/debiatan)
 - [Rod Morehead – rmorehead](https://github.com/rmorehead)
 - [Talha Mansoor – talha131](https://github.com/talha131)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,6 +40,4 @@ CSS Formatting Rules
 9. Use three digit Hex notation for colors whereever possible
 10. User hyphen `-` instead of underscore `_` in class and identity names
 
-Refer to [Google's HTML/CSS Style
-Guide](http://google-styleguide.googlecode.com/svn/trunk/htmlcssguide.xml) for
-all other formatting rules.
+Refer to [Google's HTML/CSS Style Guide](https://google.github.io/styleguide/htmlcssguide.html) for all other formatting rules.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,43 +1,60 @@
-Where do I start?
-=================
+# Where do I start?
 
-See issues tagged with [Pull Request
-Welcomed](https://github.com/talha131/pelican-elegant/issues?labels=Pull+Request+Welcomed).
-I, @talha131, do not plan to work on these issues. You are more than welcome to
-pick them up.
+Developing Elegant is a community effort, so you are very welcome to help develop it further into the most elegant theme out there.
 
-New Features and Styles
-=======================
+The main repository of Elegant is on [GitHub][elegant], which you may fork and then submit pull requests to, in order for them to be merged.
 
-If you plan to add new features to the theme, please make sure
+If you found any issues, or have ideas how to improve the theme, please submit an [issue][].
 
-1. You set sensible defaults so that theme works out of the box, without
-   forcing user to set any variable
-2. Your feature should not effect readability and reading experience
-3. It should not be distracting for the reader
+Also see issues tagged as [Pull Request Welcome](https://github.com/Pelican-Elegant/pelican-elegant/labels/pull%20request%20welcome) – these are issues that are not directly on our roadmap, but if you have time to contribute, we would be very glad to review and accept your pull request.
 
-Follow the code style of the existing codebase
-==============================================
 
-1. Use single ('') rather than double ("") quotation marks for Jinja strings
-1. In Jinja print statements, surround the variable with spaces inside curly
-   braces, for example `{{ foo.bar }}`
-1. Use double ("") quotation marks around HTML attributes
-1. End files with a newline
+# New Features and Styles
 
-CSS Formatting Rules
---------------------
+If you plan to add new features to the theme, please make sure that:
 
-1. Font name's first letter should be capital
-2. Add a space after comma
-3. Declarations should be sorted alphabetically
-4. Use a single space between the last selector and the opening brace that
-   begins the declaration block
-5. Group together related classes and identities
-6. Add a space after colon
-7. Remove leading 0s
-8. Remove unit specification after 0 values
-9. Use three digit Hex notation for colors whereever possible
-10. User hyphen `-` instead of underscore `_` in class and identity names
+1. you set sensible defaults so the theme works out of the box, without forcing the user to set any variable
+1. your changes do not negatively effect readability and reading experience
+1. your changes do not cause distraction for the reader
 
-Refer to [Google's HTML/CSS Style Guide](https://google.github.io/styleguide/htmlcssguide.html) for all other formatting rules.
+# Code style
+
+Please make sure to follow the code style of the existing codebase.
+
+Specifically:
+
+## Code/Template Formatting Rules
+
+1. use single (`''`) rather than double (`""`) quotation marks for Jinja strings
+1. in Jinja print statements, surround the variable with spaces inside curly braces – for example: `{{ foo.bar }}`
+1. use double (`""`) quotation marks around HTML attributes
+1. end files with a newline
+
+## CSS Formatting Rules
+
+1. font name's first letter should be capital
+1. add a space after comma
+1. declarations should be sorted alphabetically
+1. use a single space between the last selector and the opening brace that begins the declaration block
+1. group together related classes and identities
+1. add a space after colon
+1. remove leading 0s
+1. remove unit specification after 0 values
+1. use three-digit Hex notation for colors whereever possible
+1. use hyphen `-` instead of underscore `_` in class and identity names
+
+Refer to [Google's HTML/CSS Style Guide][google_style_guide] for all other formatting rules.
+
+
+# Licensing (Inbound=Outbound)
+
+Unless otherwise stated, all contributions will be understood to be made under the same (inbound) license as the main (outbound) license of the repository it is being contributed to – so [MIT License][] for all [code/theme][elegant] contributions, and [CC-BY-SA-3.0][] for all [documentation][] contributions.
+
+
+[elegant]: https://github.com/Pelican-Elegant/pelican-elegant
+[documentation]: https://github.com/Pelican-Elegant/documentation
+[issue]: https://github.com/Pelican-Elegant/pelican-elegant/issues/
+[contributing]: ./CONTRIBUTING.md
+[google_style_guide]: https://google.github.io/styleguide/htmlcssguide.html
+[MIT License]: https://spdx.org/licenses/MIT.html
+[CC-BY-SA-3.0]: https://spdx.org/licenses/CC-BY-SA-3.0.html

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,7 +48,9 @@ Refer to [Google's HTML/CSS Style Guide][google_style_guide] for all other forma
 
 # Licensing (Inbound=Outbound)
 
-Unless otherwise stated, all contributions will be understood to be made under the same (inbound) license as the main (outbound) license of the repository it is being contributed to – so [MIT License][] for all [code/theme][elegant] contributions, and [CC-BY-SA-3.0][] for all [documentation][] contributions.
+All contributions will be understood to be made under the same (inbound) license as the main (outbound) license of the repository it is being contributed to – so [MIT License][] for all [code/theme][elegant] contributions, and [CC-BY-SA-3.0][] for all [documentation][] contributions.
+
+If you are contributing code that is not yours, make sure to indicate where you got the code from (and who the author/copyright holder is) and what license you got it under.
 
 
 [elegant]: https://github.com/Pelican-Elegant/pelican-elegant

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,23 @@
+Valid-License-Identifier: MIT
+License-Text:
+
+MIT License
+
+Copyright (c) 2012 Contributors to the Pelican Elegant project
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is furnished
+to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS
+OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF
+OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,7 +1,0 @@
-The license requires that you give credit to me, Talha Mansoor, as the author of the Elegant theme on every site that uses this theme. I have placed the attribution in the footer of every page. Do not remove it. If you need to remove or change the style of the attribution, please get in [touch with me](http://oncrashreboot.com/#about-me) first. 
-
-Along with this attribution clause, Elegant theme is licensed under The MIT License.
-
-If you use my theme, I would love to hear from you. [Get in touch](http://oncrashreboot.com/#about-me) and let me know about it. I may link to your site too.
-
-Please visit License section of [Elegant - a theme for Pelican](http://oncrashreboot.com/pelican-elegant) at my blog for updated licensing details.

--- a/README.md
+++ b/README.md
@@ -1,19 +1,28 @@
-Please visit [Elegant - a theme for Pelican](http://oncrashreboot.com/pelican-elegant) at my blog for detailed features and documentation.
+# Elegant – an elegant theme for Pelican
 
-Elegant offers several unique features including search, live filter, collapsible comments, Mailchimp, custom 404 page, etc. It is a minimal, and stylish theme that looks amazing across all screen resolutions and devices.  
+Elegant offers several unique features including search, live filter, collapsible comments, Mailchimp, custom 404 page, etc. It is a minimal, and stylish theme that looks amazing across all screen resolutions and devices.
 
-Here is an example search result
 
-![Search result screenshot](https://raw.github.com/talha131/pelican-elegant/master/search-result-screenshot.png)
+## Screenshots
 
-Here is how the home page looks like
+Pictures are worth a thousand words. So feast your eyes on these.
+
+### Landing page
+
+Here is how the home page looks like – this is how your website would look like on visit:
 
 ![Home page screenshot](https://raw.github.com/talha131/pelican-elegant/master/home-page-screenshot.png)
 
-This is how a generated article looks like
+### Article
+
+An example how a generated article looks like:
 
 ![Article screenshot](https://raw.github.com/talha131/pelican-elegant/master/article-screenshot.png)
 
-[![githalytics.com alpha](https://cruel-carlota.pagodabox.com/c71132a529c1c5d7eb8dc5ea4825a851 "githalytics.com")](http://githalytics.com/talha131/pelican-elegant)
+### Search
 
-[![Bitdeli Badge](https://d2weczhvl823v0.cloudfront.net/talha131/pelican-elegant/trend.png)](https://bitdeli.com/free "Bitdeli Badge")
+Elegant includes a search bar – below you can see an example of a search result:
+
+![Search result screenshot](https://raw.github.com/talha131/pelican-elegant/master/search-result-screenshot.png)
+
+

--- a/README.md
+++ b/README.md
@@ -25,4 +25,15 @@ Elegant includes a search bar – below you can see an example of a search resul
 
 ![Search result screenshot](https://raw.github.com/talha131/pelican-elegant/master/search-result-screenshot.png)
 
+## Documentation
 
+The documentation is currently still hosted on [Talha Mansoor‘s homepage](http://oncrashreboot.com/elegant-best-pelican-theme-features), with its source code in [this repository][doc_repo].
+
+In the future we plan to have an separate homepage for the Elegant theme, where the documentation would be hosted as well.
+
+## License
+
+Elegant is under the [MIT license](https://spdx.org/licenses/MIT.html).
+
+
+[doc_repo]: https://github.com/Pelican-Elegant/documentation

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ See [`CONTRIBUTING.md`][contributing] for more details.
 
 ## License
 
-Elegant is released under the [MIT License][].
+Elegant is released under the [MIT License][]. See [`AUTHORS.md`][authors] file for the list of contributors.
 
 Elegant’s documentation is released under the [Creative Commons Attribution Share Alike 3.0 Unported][CC-BY-SA-3.0] license.
 
@@ -61,5 +61,6 @@ All code contributions are made directly under the [MIT License][] as well. This
 [doc_repo]: https://github.com/Pelican-Elegant/documentation
 [issue]: https://github.com/Pelican-Elegant/pelican-elegant/issues/
 [contributing]: ./CONTRIBUTING.md
+[authors]: ./AUTHORS.md
 [MIT License]: https://spdx.org/licenses/MIT.html
 [CC-BY-SA-3.0]: https://spdx.org/licenses/CC-BY-SA-3.0.html

--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # Elegant – an elegant theme for Pelican
 
-Elegant offers several unique features including search, live filter, collapsible comments, Mailchimp, custom 404 page, etc. It is a minimal, and stylish theme that looks amazing across all screen resolutions and devices.
+[Elegant][] is a theme for the static site/blog generator [Pelican][].
+
+It offers several unique features including search, live filter, collapsible comments, Mailchimp, custom 404 page, etc.
+
+It is a minimal, and stylish theme that looks amazing across all screen resolutions and devices.
 
 
 ## Screenshots
@@ -31,9 +35,31 @@ The documentation is currently still hosted on [Talha Mansoor‘s homepage](http
 
 In the future we plan to have an separate homepage for the Elegant theme, where the documentation would be hosted as well.
 
+
+## How to contribute
+
+Developing Elegant is a community effort, so you are very welcome to help develop it further into the most elegant theme out there.
+
+The main repository of Elegant is on [GitHub][elegant], which you may fork and then submit pull requests to, in order for them to be merged.
+
+If you found any issues, or have ideas how to improve the theme, please submit an [issue][].
+
+See [`CONTRIBUTING.md`][contributing] for more details.
+
+
 ## License
 
-Elegant is under the [MIT license](https://spdx.org/licenses/MIT.html).
+Elegant is released under the [MIT License][].
+
+Elegant’s documentation is released under the [Creative Commons Attribution Share Alike 3.0 Unported][CC-BY-SA-3.0] license.
+
+All contributions are made directly under the [MIT License][] as well. This is commonly referred to as the “Inbound=Outbound licensing model”, as the license everyone contributes their code under (i.e. inbound license) is exactly the same as the license that the 
 
 
+[pelican]: https://getpelican.com/
+[elegant]: https://github.com/Pelican-Elegant/pelican-elegant
 [doc_repo]: https://github.com/Pelican-Elegant/documentation
+[issue]: https://github.com/Pelican-Elegant/pelican-elegant/issues/
+[contributing]: ./CONTRIBUTING.md
+[MIT License]: https://spdx.org/licenses/MIT.html
+[CC-BY-SA-3.0]: https://spdx.org/licenses/CC-BY-SA-3.0.html

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Elegant is released under the [MIT License][].
 
 Elegant’s documentation is released under the [Creative Commons Attribution Share Alike 3.0 Unported][CC-BY-SA-3.0] license.
 
-All contributions are made directly under the [MIT License][] as well. This is commonly referred to as the “Inbound=Outbound licensing model”, as the license everyone contributes their code under (i.e. inbound license) is exactly the same as the license that the 
+All code contributions are made directly under the [MIT License][] as well. This is commonly referred to as the “Inbound=Outbound licensing model”, as the license everyone contributes their code under (i.e. inbound license) is exactly the same as the license that the code is then being released under to the general public.
 
 
 [pelican]: https://getpelican.com/

--- a/THANKS.md
+++ b/THANKS.md
@@ -1,6 +1,8 @@
 Thanks to
 =========
 
+**Extra Special Thanks** to [talha131](https://github.com/talha131) for creating this theme and for being the sole maintainer and main developer of Elegant for so many years, and later opening up the development to a community-led effort, enabling the theme and its community to grow.
+
 **Special Thanks** to [calfzhou](https://github.com/calfzhou) and
 [tshepang](https://github.com/tshepang). They are always the first to report
 issues, suggest improvements and submit patches. They have played a huge role
@@ -25,13 +27,7 @@ in making Elegant more elegant.
 1. He reported, investigated and submitted a
    [patch](https://github.com/talha131/pelican-elegant/issues/110) for an issue
    in the navbar
-
-[Andre](https://github.com/andreburgaud)
-----------------------------------------
-
-1. He [reported and submitted a
-   patch](https://github.com/talha131/pelican-elegant/issues/108) to fix a bug
-   in 404.html
+1. He [reported and submitted a patch](https://github.com/talha131/pelican-elegant/issues/108) to fix a bug in 404.html
 
 [brechtm](https://github.com/brechtm)
 -------------------------------------

--- a/templates/_includes/footer.html
+++ b/templates/_includes/footer.html
@@ -9,7 +9,7 @@
         {% if SITE_LICENSE %}
         <li class="elegant-license">{{ SITE_LICENSE }}</li>
         {% endif %}
-        <li class="elegant-power">Powered by <a href="http://getpelican.com/" title="Pelican Home Page">Pelican</a>. Theme: <a href="http://oncrashreboot.com/pelican-elegant" title="Theme Elegant Home Page">Elegant</a> by <a href="http://oncrashreboot.com" title="Talha Mansoor Home Page">Talha Mansoor</a></li>
+        <li class="elegant-power">Powered by <a href="http://getpelican.com/" title="Pelican Home Page">Pelican</a>. Theme: <a href="https://github.com/Pelican-Elegant/pelican-elegant/" title="Theme Elegant Home Page">Elegant</a></li>
     </ul>
 </div>
 </footer>


### PR DESCRIPTION
This would fix https://github.com/Pelican-Elegant/pelican-elegant/issues/175

It should address all issues listed in that issue.

This pull request does not address the following though, which should be addressed later:

- whether we want a different mechanism of attribution and thanks – e.g. [All Contributors](https://github.com/kentcdodds/all-contributors)
- there are a few more steps missing for the repository to be fully compliant with the https://reuse.software spec

Since we clarifying the license of mainly @talha131’s work, it is only correct he should be the one to review these changes.

Especially, I would like someone to double-check (preferably themselves) that the list of authors/copyright holders in `AUTHORS.md` is correct:

- @andreburgaud
- @bnice5000
- @silverhook
- @debiatan
- @rmorehead
- @talha131
- @tshepang
- @calfzhou 
- @yuex

If anyone is missing, added without reason, or their name is spelled wrong in the file, I humbly apologise and ask how to fix this.